### PR TITLE
Unify pip_install and resolve package version conflicts

### DIFF
--- a/PlaneCNN/InferenceLib/data_utils/GeomCnnDataset.py
+++ b/PlaneCNN/InferenceLib/data_utils/GeomCnnDataset.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
-from monai.transforms import AddChannel
+from monai.transforms import EnsureChannelFirst
 from monai.transforms import Compose
 from monai.transforms import LoadImage
 from monai.transforms import ScaleIntensity
@@ -25,7 +25,7 @@ class GeomCnnDataModule(pl.LightningDataModule):
         self.val_frac = val_frac
         self.FILE_PATHS = file_paths
         self.test_transform = Compose(
-                [LoadImage(image_only=True), AddChannel(), ScaleIntensity(), EnsureType()]
+            [LoadImage(image_only=True), EnsureChannelFirst(channel_dim='no_channel'), ScaleIntensity(), EnsureType()]
             )
         self.data_tuple = data_tuple
         self.save_hyperparameters()

--- a/PlaneCNN/InferenceLib/data_utils/GeomCnnDataset.py
+++ b/PlaneCNN/InferenceLib/data_utils/GeomCnnDataset.py
@@ -1,22 +1,15 @@
 from typing import Optional
+
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
-
-
-from monai.transforms import (
-    AddChannel,
-    Compose,
-    LoadImage,
-    RandFlip,
-    RandRotate,
-    RandZoom,
-    ScaleIntensity,
-    EnsureType,
-)
+from monai.transforms import AddChannel
+from monai.transforms import Compose
+from monai.transforms import LoadImage
+from monai.transforms import ScaleIntensity
+from monai.transforms import EnsureType
 
 from InferenceLib.data_utils.utils import get_image_files_single_scalar
 from InferenceLib.data_utils.CustomDataset import GeomCnnDataset
-from sklearn.model_selection import train_test_split
 
 
 class GeomCnnDataModule(pl.LightningDataModule):

--- a/PlaneCNN/InferenceLib/data_utils/utils.py
+++ b/PlaneCNN/InferenceLib/data_utils/utils.py
@@ -2,7 +2,11 @@ import os
 
 import pandas as pd
 import torch.utils.data
-from monai.transforms import LoadImage, AddChannel, ScaleIntensity, EnsureType, Compose
+from monai.transforms import LoadImage
+from monai.transforms import AddChannel
+from monai.transforms import ScaleIntensity
+from monai.transforms import EnsureType
+from monai.transforms import Compose
 
 from InferenceLib.CONSTANTS import DEFAULT_FILE_PATHS
 from InferenceLib.data_utils.CustomDataset import GeomCnnDataset

--- a/PlaneCNN/InferenceLib/data_utils/utils.py
+++ b/PlaneCNN/InferenceLib/data_utils/utils.py
@@ -3,7 +3,7 @@ import os
 import pandas as pd
 import torch.utils.data
 from monai.transforms import LoadImage
-from monai.transforms import AddChannel
+from monai.transforms import EnsureChannelFirst
 from monai.transforms import ScaleIntensity
 from monai.transforms import EnsureType
 from monai.transforms import Compose
@@ -49,7 +49,7 @@ def get_test_dataloader():
     test_files, test_labels = get_image_files_single_scalar("TEST_DATA_DIR")
     test_transform = Compose(
         [LoadImage(image_only=True),
-         AddChannel(),
+         EnsureChannelFirst(channel_dim='no_channel'),
          ScaleIntensity(),
          EnsureType()]
     )

--- a/PlaneCNN/PlaneCNN.py
+++ b/PlaneCNN/PlaneCNN.py
@@ -1,34 +1,22 @@
 import os
 import pathlib
 import logging
-import vtk, qt, ctk, slicer
+
+import vtk
+import qt
+import ctk
+import slicer
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
 
 from PlaneCNNUtil.CheckableComboBox import CheckableComboBox
+from PlaneCNNUtil import ensure_requirements
 
-try:
-    import numpy as np
-except ImportError:
-    slicer.util.pip_install('numpy==1.21.2')
-    import numpy as np
+ensure_requirements()
 
-try:
-    import torch
-except ImportError:
-    slicer.util.pip_install('torch==1.9.0')
-    import torch
+import numpy as np
 
-try:
-    import pytorch_lightning as pl
-except ImportError:
-    slicer.util.pip_install('pytorch_lightning==1.4.9')
-    import pytorch_lightning as pl
-
-try:
-    import sklearn
-except ImportError:
-    slicer.util.pip_install('scikit-learn==0.24.2')
+import torch
 
 from InferenceLib.CONSTANTS import DEFAULT_FILE_PATHS
 from InferenceLib.Asynchrony import Asynchrony

--- a/PlaneCNN/PlaneCNNUtil/CheckableComboBox.py
+++ b/PlaneCNN/PlaneCNNUtil/CheckableComboBox.py
@@ -1,4 +1,6 @@
-from qt import QApplication, QComboBox, QMainWindow, QWidget, QVBoxLayout, QStandardItemModel, Qt
+from qt import QComboBox
+from qt import QStandardItemModel
+from qt import Qt
 
 
 # creating checkable combo box class

--- a/PlaneCNN/PlaneCNNUtil/__init__.py
+++ b/PlaneCNN/PlaneCNNUtil/__init__.py
@@ -1,0 +1,41 @@
+requirements = [
+    "Pillow",
+    "monai==0.7",
+    "pandas",
+    "pytorch_lightning",
+    "scikit_learn",
+    "tensorboard",
+    "torch",
+    "torchmetrics",
+]
+
+
+# noinspection PyUnresolvedReferences
+def ensure_requirements():
+    # Imports are ensured at the top-level, once, when the module is initialized. So this function is a no-op,
+    # but will explicitly fail if any requirement is missing. Note that this function does _not_ check
+    # version constraints; use `install_requirements()` for that.
+
+    import torch
+    import pytorch_lightning
+    import pandas
+    import torchmetrics
+    import sklearn
+    import PIL
+    import monai
+
+
+def install_requirements(upgrade=False):
+    import slicer.util
+
+    args = [*requirements]
+    if upgrade:
+        args.append("-U")
+
+    slicer.util.pip_install(args)
+
+
+try:
+    ensure_requirements()
+except ImportError:
+    install_requirements()

--- a/PlaneCNN/PlaneCNNUtil/__init__.py
+++ b/PlaneCNN/PlaneCNNUtil/__init__.py
@@ -1,6 +1,6 @@
 requirements = [
     "Pillow",
-    "monai==0.7",
+    "monai>=0.8",
     "pandas",
     "pytorch_lightning",
     "scikit_learn",

--- a/PlaneCNNTrainer/DeepLearnerLib/data_utils/GeomCnnDataset.py
+++ b/PlaneCNNTrainer/DeepLearnerLib/data_utils/GeomCnnDataset.py
@@ -1,28 +1,23 @@
 from typing import Optional
+import logging
+from operator import itemgetter
+
 import numpy as np
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
-import logging
 from sklearn.model_selection import StratifiedKFold
-from operator import itemgetter
-
-
-from monai.transforms import (
-    AddChannel,
-    Compose,
-    LoadImage,
-    RandFlip,
-    RandRotate,
-    RandZoom,
-    ScaleIntensity,
-    NormalizeIntensity,
-    EnsureType,
-)
+from monai.transforms import AddChannel
+from monai.transforms import Compose
+from monai.transforms import LoadImage
+from monai.transforms import RandFlip
+from monai.transforms import RandRotate
+from monai.transforms import RandZoom
+from monai.transforms import NormalizeIntensity
+from monai.transforms import EnsureType
+from sklearn.model_selection import train_test_split
 
 from DeepLearnerLib.data_utils.utils import get_image_files_single_scalar
 from DeepLearnerLib.data_utils.CustomDataset import GeomCnnDataset
-from sklearn.model_selection import train_test_split
-from PIL import Image
 
 
 class GeomCnnDataModule(pl.LightningDataModule):

--- a/PlaneCNNTrainer/DeepLearnerLib/data_utils/GeomCnnDataset.py
+++ b/PlaneCNNTrainer/DeepLearnerLib/data_utils/GeomCnnDataset.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
 from sklearn.model_selection import StratifiedKFold
-from monai.transforms import AddChannel
+from monai.transforms import EnsureChannelFirst
 from monai.transforms import Compose
 from monai.transforms import LoadImage
 from monai.transforms import RandFlip
@@ -36,7 +36,7 @@ class GeomCnnDataModule(pl.LightningDataModule):
         self.train_transforms = Compose(
             [
                 LoadImage(image_only=True),
-                AddChannel(),
+                EnsureChannelFirst(channel_dim='no_channel'),
                 NormalizeIntensity(),
                 RandRotate(range_x=np.pi / 12, prob=0.5, keep_size=True),
                 RandFlip(spatial_axis=0, prob=0.5),
@@ -45,10 +45,10 @@ class GeomCnnDataModule(pl.LightningDataModule):
             ]
         )
         self.val_transforms = Compose(
-            [LoadImage(image_only=True), AddChannel(), NormalizeIntensity(), EnsureType()]
+            [LoadImage(image_only=True), EnsureChannelFirst(channel_dim='no_channel'), NormalizeIntensity(), EnsureType()]
         )
         self.test_transform = Compose(
-                [LoadImage(image_only=True), AddChannel(), NormalizeIntensity(), EnsureType()]
+                [LoadImage(image_only=True), EnsureChannelFirst(channel_dim='no_channel'), NormalizeIntensity(), EnsureType()]
             )
         self.data_tuple = data_tuple
         self.save_hyperparameters()

--- a/PlaneCNNTrainer/DeepLearnerLib/data_utils/utils.py
+++ b/PlaneCNNTrainer/DeepLearnerLib/data_utils/utils.py
@@ -3,7 +3,7 @@ import os
 import pandas as pd
 import torch.utils.data
 from monai.transforms import LoadImage
-from monai.transforms import AddChannel
+from monai.transforms import EnsureChannelFirst
 from monai.transforms import ScaleIntensity
 from monai.transforms import EnsureType
 from monai.transforms import Compose
@@ -55,7 +55,7 @@ def get_test_dataloader():
     test_files, test_labels = get_image_files_single_scalar("TEST_DATA_DIR")
     test_transform = Compose(
         [LoadImage(image_only=True),
-         AddChannel(),
+         EnsureChannelFirst(channel_dim='no_channel'),
          ScaleIntensity(),
          EnsureType()]
     )

--- a/PlaneCNNTrainer/DeepLearnerLib/data_utils/utils.py
+++ b/PlaneCNNTrainer/DeepLearnerLib/data_utils/utils.py
@@ -1,9 +1,12 @@
 import os
 
-import numpy as np
 import pandas as pd
 import torch.utils.data
-from monai.transforms import LoadImage, AddChannel, ScaleIntensity, EnsureType, Compose
+from monai.transforms import LoadImage
+from monai.transforms import AddChannel
+from monai.transforms import ScaleIntensity
+from monai.transforms import EnsureType
+from monai.transforms import Compose
 
 from DeepLearnerLib.CONSTANTS import DEFAULT_FILE_PATHS
 from DeepLearnerLib.data_utils.CustomDataset import GeomCnnDataset

--- a/PlaneCNNTrainer/DeepLearnerLib/models/cnn_model.py
+++ b/PlaneCNNTrainer/DeepLearnerLib/models/cnn_model.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 
 from monai.networks.blocks import Convolution

--- a/PlaneCNNTrainer/DeepLearnerLib/prediction/predict.py
+++ b/PlaneCNNTrainer/DeepLearnerLib/prediction/predict.py
@@ -1,8 +1,5 @@
-import pytorch_lightning as pl
-import torch
 import torchmetrics
 
-from DeepLearnerLib.data_utils.GeomCnnDataset import GeomCnnDataModule
 from DeepLearnerLib.data_utils.utils import get_test_dataloader
 from DeepLearnerLib.pl_modules.classifier_modules import ImageClassifier
 

--- a/PlaneCNNTrainer/DeepLearnerLib/training/EfficientNetTrainer.py
+++ b/PlaneCNNTrainer/DeepLearnerLib/training/EfficientNetTrainer.py
@@ -2,56 +2,22 @@ import logging
 import os.path
 from argparse import ArgumentParser
 
-import slicer
+import pytorch_lightning as pl
+import torch
+import torch.nn
+from monai.networks.nets import EfficientNetBN
+from monai.networks.nets import DenseNet
+from monai.networks.nets import SEResNet50
+from pytorch_lightning.loggers import TensorBoardLogger
+from pytorch_lightning.callbacks import EarlyStopping
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.callbacks.progress import ProgressBarBase
 
 from DeepLearnerLib.Asynchrony import Asynchrony
-
-try:
-    import pytorch_lightning as pl
-except ImportError:
-    slicer.util.pip_install('pytorch_lightning==1.4.9')
-    import pytorch_lightning as pl
-
-try:
-    import torch
-except ImportError:
-    slicer.util.pip_install('torch==1.9.0')
-    import torch
-
-try:
-    import monai
-except ImportError:
-    slicer.util.pip_install('monai==0.7.0')
-
-try:
-    import pandas
-except ImportError:
-    slicer.util.pip_install('pandas==1.1.5')
-
-try:
-    import torchmetrics
-except ImportError:
-    slicer.util.pip_install('torchmetrics==0.6.0')
-
-try:
-    import sklearn
-except ImportError:
-    slicer.util.pip_install('scikit-learn==0.24.2')
-
-try:
-    import PIL
-except ImportError:
-    slicer.util.pip_install("Pillow==8.3.1")
-
-import torch.nn
-from monai.networks.nets import EfficientNetBN, DenseNet, SEResNet50
-
 from DeepLearnerLib.models.cnn_model import SimpleCNN
 from DeepLearnerLib.pl_modules.classifier_modules import ImageClassifier
-from DeepLearnerLib.data_utils.GeomCnnDataset import GeomCnnDataModule, GeomCnnDataModuleKFold
-from pytorch_lightning.loggers import TensorBoardLogger
-from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
-from pytorch_lightning.callbacks.progress import ProgressBarBase
+from DeepLearnerLib.data_utils.GeomCnnDataset import GeomCnnDataModule
+from DeepLearnerLib.data_utils.GeomCnnDataset import GeomCnnDataModuleKFold
 
 
 def weight_reset(m):

--- a/PlaneCNNTrainer/PlaneCNNTrainer.py
+++ b/PlaneCNNTrainer/PlaneCNNTrainer.py
@@ -1,23 +1,25 @@
 import glob
 import os
 import logging
-import vtk, qt, ctk, slicer
-from slicer.ScriptedLoadableModule import *
-from slicer.util import VTKObservationMixin
 from pathlib import Path
 import webbrowser
+
+import vtk
+import qt
+import ctk
+import slicer
+from slicer.ScriptedLoadableModule import *
+from slicer.util import VTKObservationMixin
 from PIL import Image
 
 from DeepLearnerLib.CONSTANTS import DEFAULT_FILE_PATHS
 from DeepLearnerLib.Asynchrony import Asynchrony
 from PlaneCNNTrainerUtil.CheckableComboBox import CheckableComboBox
+from PlaneCNNUtil import ensure_requirements
 
-try:
-    import tensorboard
-except ImportError:
-    slicer.util.pip_install('tensorboard==2.7.0')
-    import tensorboard
+ensure_requirements()
 
+import tensorboard
 from tensorboard import program
 
 

--- a/PlaneCNNTrainer/PlaneCNNTrainerUtil/CheckableComboBox.py
+++ b/PlaneCNNTrainer/PlaneCNNTrainerUtil/CheckableComboBox.py
@@ -1,4 +1,6 @@
-from qt import QApplication, QComboBox, QMainWindow, QWidget, QVBoxLayout, QStandardItemModel, Qt
+from qt import QComboBox
+from qt import QStandardItemModel
+from qt import Qt
 
 
 # creating checkable combo box class

--- a/SurfacePlaneMapper/SurfacePlaneMapper.py
+++ b/SurfacePlaneMapper/SurfacePlaneMapper.py
@@ -1,12 +1,14 @@
 import logging
-try:
-    import scipy
-except ImportError:
-    slicer.util.pip_install('scipy==1.7.1')
 
-import vtk, qt, slicer
+import vtk
+import qt
+import slicer
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin
+
+from PlaneCNNUtil import ensure_requirements
+
+ensure_requirements()
 
 from SurfacePlaneMapperUtil.Asynchrony import Asynchrony
 from geometry_image.tools.run import run_geom_image

--- a/SurfacePlaneMapper/geometry_image/tools/perform_sgim_sampling.py
+++ b/SurfacePlaneMapper/geometry_image/tools/perform_sgim_sampling.py
@@ -1,27 +1,10 @@
 from pathlib import Path
-
-import slicer
 import os
 import pickle
 import argparse
 
-try:
-    import numpy as p
-except ImportError:
-    slicer.util.pip_install('numpy==1.20.3')
-
-try:
-    import vtk
-except ImportError:
-    slicer.util.pip_install('vtk==9.0.3')
-
+import numpy as np
 from vtk.util.numpy_support import vtk_to_numpy
-
-try:
-    import PIL
-except ImportError:
-    slicer.util.pip_install('Pillow==8.3.1')
-
 from PIL import Image
 
 from geometry_image.tools.vtk_tools import *

--- a/SurfacePlaneMapper/geometry_image/tools/run.py
+++ b/SurfacePlaneMapper/geometry_image/tools/run.py
@@ -1,6 +1,7 @@
+import numpy as np
+
 from SurfacePlaneMapperUtil.Asynchrony import Asynchrony
 from geometry_image.tools.perform_sgim_sampling import *
-from pathlib import Path
 
 
 def run_geom_image(args):

--- a/SurfacePlaneMapper/geometry_image/tools/vtk_tools.py
+++ b/SurfacePlaneMapper/geometry_image/tools/vtk_tools.py
@@ -1,5 +1,4 @@
 import vtk
-import numpy as np
 
 
 def ReadPolyData(file_name):


### PR DESCRIPTION
This depends on the changes in  #1 and #5, so should not be merged until after those PRs have been merged and this PR rebased on the new main.

Move all the extension dependencies into a single requirements list in PlaneCNNUtils/__init__.py; this automatically installs those requirements if any dependency cannot be imported.

From the Python REPL you can also `PlaneCNNUtils.install_requirements()` to have pip attempt to satisfy any changes to constraints, or `PlaneCNNUtils.install_requirements(upgrade=True)` to install the newest version of all packages that satisfy version constraints.

---

I also ran the "optimize imports" code action on all python files to hopefully make it easier to audit which files depend on which packages.

---

The previously-required MONAI version was 0.7, relatively out-of-date. I've relaxed that constraint to `>=0.8`, but this required replacing the deprecated `AddChannel` transform with `EnsureChannelFirst`.